### PR TITLE
Build-time configure backend address

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,8 +23,11 @@ jobs:
       - name: Install Dependencies
         run: npm install
 
+      - name: Set backend env
+        run: (echo "${GITHUB_REF##*/}" | grep -Eq  '^(develop)|(predev)$' ) && (echo "SUBDOMAIN=${GITHUB_REF##*/}." >> $GITHUB_ENV ) || echo "Standart"
+
       - name: Build for production
-        run: CI= npm run build
+        run: REACT_APP_BACKEND=http://${SUBDOMAIN}nl-mail.ru CI= npm run build
       
       - name: Files list
         run: ls && ls build/

--- a/src/utils/Config/Config.js
+++ b/src/utils/Config/Config.js
@@ -1,2 +1,2 @@
-export const BACKEND_ADDRESS = 'http://nl-mail.ru';
+export const BACKEND_ADDRESS = process.env.REACT_APP_BACKEND || 'http://nl-mail.ru';
 export const CORS_CONST = 'cors';


### PR DESCRIPTION
Выставляем адрес бэка на этапе сборки в зависимости от имени ветки. Для develop/predev ставится соответствующий поддомен, для остальных остается стандартный.